### PR TITLE
add dynamic bone

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Some out-of-the-box utility features based on the [Galacean engine](https://gith
 - ➡️ &nbsp;**[Gizmo](packages/gizmo)** - Operation tools for transforming (displacement, rotation, scaling)
 - 🧭 &nbsp;**[Navigation Gizmo](packages/navigation-gizmo)** - Three-view & visualized operation for camera control
 - 🛣 &nbsp;**[Waypoint](packages/way-point)** - control entity move along waypoint
+- 🪁 &nbsp;**[Dynamic Bone](packages/dynamic-bone)** - use dynamic spring movement to enhance skeleton animation
 
 - 📐 &nbsp;**[Lines](packages/lines)** - 2D Solid Line & Dash Line
 - 🖇 &nbsp;**[Auxiliary Lines](packages/auxiliary-lines)** - Draw wireframe for entity and component

--- a/packages/dynamic-bone/README.md
+++ b/packages/dynamic-bone/README.md
@@ -1,0 +1,46 @@
+# Dynamic Bone
+
+Dynamic bones are generally used to add physics-based animation to character animation, and can be used for hair,
+ribbons, tails, and even clothing. Enhanced effects of original character animation.
+
+Although spring motion can also be realized with a physics engine such as PhysX, dynamic bones generally need to
+customize some motion curves to meet artistic needs. Therefore, this repository implements a custom small physics engine
+to meet this requirement. This physics engine only implements particle-based spring animation, plus Capsule, Sphere,
+and Plane colliders.
+
+## Features
+
+- Dynamic Bone: Spring movement
+- Sphere Collider
+- Capsule Collider
+- Plane Collider
+
+## npm
+
+The `Dynamic bones` is published on npm with full typing support. To install, use:
+
+```sh
+npm install @galacean/engine-toolkit-dynamic-bone
+```
+
+This will allow you to import package entirely using:
+
+```javascript
+import * as TOOLKIT from "@galacean/engine-toolkit-dynamic-bone";
+```
+
+or individual classes using:
+
+```javascript
+import { DynamicBone } from "@galacean/engine-toolkit-dynamic-bone";
+```
+
+## Links
+
+- [Repository](https://github.com/galacean/engine-toolkit)
+- [Documentation](https://oasisengine.cn/#/docs/latest/cn/install)
+- [API References](https://oasisengine.cn/#/api/latest/core)
+
+## License
+
+The engine is released under the [MIT](https://opensource.org/licenses/MIT) license. See LICENSE file.

--- a/packages/dynamic-bone/package.json
+++ b/packages/dynamic-bone/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@galacean/engine-toolkit-dynamic-bone",
+  "version": "1.0.0-beta.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "homepage": "https://oasisengine.cn/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galacean/engine-toolkit"
+  },
+  "bugs": "https://github.com/galacean/engine-toolkit/issues",
+  "license": "MIT",
+  "scripts": {
+    "b:types": "tsc",
+    "lint:fix": "tslint --fix --project ./tsconfig.json"
+  },
+  "types": "types/index.d.ts",
+  "main": "dist/commonjs/browser.js",
+  "module": "dist/es/index.js",
+  "files": [
+    "dist/**/*",
+    "types/**/*"
+  ],
+  "peerDependencies": {
+    "@galacean/engine": "^1.0.0-alpha"
+  }
+}

--- a/packages/dynamic-bone/src/DynamicBone.ts
+++ b/packages/dynamic-bone/src/DynamicBone.ts
@@ -1,0 +1,757 @@
+import { CollisionUtil, MathUtil, Matrix, Plane, Quaternion, Script, Transform, Vector3 } from "@galacean/engine";
+import { DynamicBoneColliderBase } from "./DynamicBoneColliderBase";
+import { MathCommon } from "./MathCommon";
+
+export enum UpdateMode {
+  Normal,
+  AnimatePhysics,
+  UnscaledTime,
+  Default
+}
+
+export enum FreezeAxis {
+  None = 0,
+  X = 1,
+  Y = 2,
+  Z = 3
+}
+
+export class DynamicBone extends Script {
+  private static _tempVec1 = new Vector3();
+  private static _tempVec2 = new Vector3();
+  private static _tempVec3 = new Vector3();
+  private static _tempQuat = new Quaternion();
+  private static _tempMatrix = new Matrix();
+  private static _tempPlane = new Plane();
+
+  private static _updateCount: number = 0;
+  private static _prepareFrame: number = 0;
+
+  /// The roots of the transform hierarchy to apply physics.
+  public root: Transform = null;
+  public roots: Transform[] = [];
+
+  /// Internal physics simulation rate.
+  public updateRate: number = 60.0;
+
+  public updateMode = UpdateMode.Default;
+
+  /// How much the bones slowed down.
+  public damping: number = 0.1;
+
+  /// How much the force applied to return each bone to original orientation.
+  public elasticity: number = 0.1;
+
+  /// How much bone's original orientation are preserved.
+  public stiffness: number = 0.1;
+
+  /// How much character's position change is ignored in physics simulation.
+  public inert: number = 0;
+
+  /// How much the bones slowed down when collided.
+  public friction: number = 0;
+
+  /// Each bone can be a sphere to collide with colliders. Radius describe sphere's size.
+  public radius: number = 0;
+
+  /// If End Length is not zero, an extra bone is generated at the end of transform hierarchy.
+  public endLength: number = 0;
+
+  /// If End Offset is not zero, an extra bone is generated at the end of transform hierarchy.
+  public endOffset = new Vector3();
+
+  /// The force apply to bones. Partial force apply to character's initial pose is cancelled out.
+  public gravity = new Vector3();
+
+  /// The force apply to bones.
+  public force = new Vector3();
+
+  /// Control how physics blends with existing animation.
+  public blendWeight: number = 1.0;
+
+  /// Collider objects interact with the bones.
+  public colliders: DynamicBoneColliderBase[] = [];
+
+  /// Bones exclude from physics simulation.
+  public exclusions: Transform[] = [];
+
+  /// Constrain bones to move on specified plane.
+  public freezeAxis = FreezeAxis.None;
+
+  /// Disable physics simulation automatically if character is far from camera or player.
+  public distantDisable = false;
+  public referenceObject: Transform = null;
+  public distanceToObject: number = 20;
+
+  private _objectMove = new Vector3();
+  private _objectPrevPosition = new Vector3();
+  private _objectScale: number = 0;
+
+  private _time: number = 0;
+  private _weight: number = 1.0;
+  private _distantDisabled: boolean = false;
+  private _preUpdateCount: number = 0;
+
+  private _particleTrees: ParticleTree[] = [];
+
+  // prepare data
+  private _deltaTime: number = 0;
+  private _effectiveColliders: DynamicBoneColliderBase[] = [];
+
+  public setWeight(w: number): void {
+    if (this._weight != w) {
+      if (w == 0) {
+        this._initTransforms();
+      } else if (this._weight == 0) {
+        this._resetParticlesPosition();
+      }
+      this._weight = w;
+      this.blendWeight = w;
+    }
+  }
+
+  public getWeight(): number {
+    return this._weight;
+  }
+
+  /**
+   * @internal
+   */
+  override onStart(): void {
+    this._setupParticles();
+  }
+
+  /**
+   * @internal
+   */
+  override onEnable(): void {
+    this._resetParticlesPosition();
+  }
+
+  /**
+   * @internal
+   */
+  override onDisable(): void {
+    this._initTransforms();
+  }
+
+  /**
+   * @internal
+   */
+  override onPhysicsUpdate(): void {
+    if (this.updateMode == UpdateMode.AnimatePhysics) {
+      this._preUpdate();
+    }
+  }
+
+  /**
+   * @internal
+   */
+  override onUpdate(deltaTime: number): void {
+    if (this.updateMode != UpdateMode.AnimatePhysics) {
+      this._preUpdate();
+    }
+    DynamicBone._updateCount += 1;
+  }
+
+  /**
+   * @internal
+   */
+  override onLateUpdate(deltaTime: number): void {
+    if (this._preUpdateCount == 0) {
+      return;
+    }
+
+    if (DynamicBone._updateCount > 0) {
+      DynamicBone._updateCount = 0;
+      DynamicBone._prepareFrame += 1;
+    }
+
+    this.setWeight(this.blendWeight);
+
+    this._checkDistance();
+    if (this._isNeedUpdate()) {
+      this._prepare();
+      this._updateParticles();
+      this._applyParticlesToTransforms();
+    }
+    this._preUpdateCount = 0;
+  }
+
+  private _prepare(): void {
+    this._deltaTime = this.engine.time.deltaTime;
+
+    const transform = this.entity.transform!;
+    this._objectScale = Math.abs(transform.lossyWorldScale.x);
+    Vector3.subtract(transform.worldPosition, this._objectPrevPosition, this._objectMove);
+    this._objectPrevPosition.copyFrom(transform.worldPosition);
+
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      const pt = this._particleTrees[i];
+      Vector3.transformToVec3(pt._localGravity, pt._root!.worldMatrix, pt._restGravity);
+
+      for (let j = 0; j < pt._particles.length; j++) {
+        const p = pt._particles[j];
+        const transform = p._transform;
+        if (transform != null) {
+          p._transformPosition.copyFrom(transform.worldPosition);
+          p._transformLocalPosition.copyFrom(transform.position);
+          p._transformLocalToWorldMatrix.copyFrom(transform.worldMatrix);
+        }
+      }
+    }
+
+    this._effectiveColliders.length = 0;
+
+    for (let i = 0; i < this.colliders.length; i++) {
+      const c = this.colliders[i];
+      if (c.enabled) {
+        this._effectiveColliders.length = 0;
+        this._effectiveColliders.push(c);
+
+        if (c.prepareFrame != DynamicBone._prepareFrame) {
+          // colliders used by many dynamic bones only prepares once
+          c.prepare();
+          c.prepareFrame = DynamicBone._prepareFrame;
+        }
+      }
+    }
+  }
+
+  private _updateParticles(): void {
+    if (this._particleTrees.length <= 0) {
+      return;
+    }
+
+    let loop = 1;
+    let timeVar: number = 1;
+    const dt = this._deltaTime;
+
+    if (this.updateMode == UpdateMode.Default) {
+      if (this.updateRate > 0) {
+        timeVar = dt * this.updateRate;
+      }
+    } else {
+      if (this.updateRate > 0) {
+        const frameTime = 1.0 / this.updateRate;
+        this._time += dt;
+        loop = 0;
+
+        while (this._time >= frameTime) {
+          this._time -= frameTime;
+          loop += 1;
+          if (loop >= 3) {
+            this._time = 0;
+            break;
+          }
+        }
+      }
+    }
+
+    if (loop > 0) {
+      for (let i = 0; i < loop; i++) {
+        this._updateParticles1(timeVar, i);
+        this._updateParticles2(timeVar);
+      }
+    } else {
+      this._skipUpdateParticles();
+    }
+  }
+
+  private _setupParticles(): void {
+    this._particleTrees.length = 0;
+
+    if (this.root != null) {
+      this._appendParticleTree(this.root);
+    }
+
+    if (this.roots.length != 0) {
+      for (let i = 0; i < this.roots.length; i++) {
+        const root = this.roots[i];
+        const result = this._particleTrees.find((value, index, obj) => {
+          return value._root === root;
+        });
+
+        if (result !== undefined) {
+          continue;
+        }
+        this._appendParticleTree(root);
+      }
+    }
+
+    const transform = this.entity.transform!;
+    this._objectScale = Math.abs(transform.lossyWorldScale.x);
+    this._objectPrevPosition.copyFrom(transform.worldPosition);
+    this._objectMove.set(0, 0, 0);
+
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      const pt = this._particleTrees[i];
+      this._appendParticles(pt, pt._root, -1, 0);
+    }
+    this._updateParameters();
+  }
+
+  private _updateParameters(): void {
+    this.setWeight(this.blendWeight);
+
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._updateSingleParameters(this._particleTrees[i]);
+    }
+  }
+
+  private _updateSingleParameters(pt: ParticleTree): void {
+    Vector3.transformToVec3(this.gravity, pt._rootWorldToLocalMatrix, pt._localGravity);
+
+    for (let i = 0; i < pt._particles.length; i++) {
+      const p = pt._particles[i];
+      p._damping = this.damping;
+      p._elasticity = this.elasticity;
+      p._stiffness = this.stiffness;
+      p._inert = this.inert;
+      p._friction = this.friction;
+      p._radius = this.radius;
+
+      p._damping = MathUtil.clamp(p._damping, 0, 1);
+      p._elasticity = MathUtil.clamp(p._elasticity, 0, 1);
+      p._stiffness = MathUtil.clamp(p._stiffness, 0, 1);
+      p._inert = MathUtil.clamp(p._inert, 0, 1);
+      p._friction = MathUtil.clamp(p._friction, 0, 1);
+      p._radius = Math.max(p._radius, 0);
+    }
+  }
+
+  private _appendParticleTree(root: Transform): void {
+    const pt = new ParticleTree();
+    pt._root = root;
+    Matrix.invert(root.worldMatrix, pt._rootWorldToLocalMatrix);
+    this._particleTrees.push(pt);
+  }
+
+  private _appendParticles(pt: ParticleTree, b: Transform, parentIndex: number, boneLength: number): void {
+    const p = new Particle();
+    p._transform = b;
+    p._parentIndex = parentIndex;
+
+    if (b != null) {
+      p._position.copyFrom(b.worldPosition);
+      p._prevPosition.copyFrom(b.worldPosition);
+      p._initLocalPosition.copyFrom(b.position);
+      p._initLocalRotation.copyFrom(b.rotationQuaternion);
+    } // end bone
+    else {
+      const pb = pt._particles[parentIndex]._transform!;
+      const invertMat = new Matrix();
+      Matrix.invert(pb.worldMatrix, invertMat);
+      if (this.endLength > 0) {
+        const ppb = pb.entity.parent;
+        if (ppb != null) {
+          Vector3.scale(pb.worldPosition, 2, DynamicBone._tempVec1);
+          Vector3.subtract(DynamicBone._tempVec1, ppb.transform.worldPosition, DynamicBone._tempVec1);
+          Vector3.transformCoordinate(DynamicBone._tempVec1, invertMat, p._endOffset);
+          p._endOffset.scale(this.endLength);
+        } else {
+          p._endOffset.set(this.endLength, 0, 0);
+        }
+      } else {
+        const offset = DynamicBone._tempVec1;
+        Vector3.transformToVec3(this.endOffset, this.entity.transform.worldMatrix, offset);
+        offset.add(pb.worldPosition);
+        Vector3.transformCoordinate(offset, invertMat, p._endOffset);
+      }
+      const offset = DynamicBone._tempVec1;
+      Vector3.transformCoordinate(p._endOffset, pb.worldMatrix, offset);
+      p._position.copyFrom(offset);
+      p._prevPosition.copyFrom(offset);
+      p._initLocalPosition.set(0, 0, 0);
+      p._initLocalRotation.set(0, 0, 0, 1);
+    }
+
+    if (parentIndex >= 0) {
+      Vector3.subtract(pt._particles[parentIndex]._transform!.worldPosition, p._position, DynamicBone._tempVec1);
+      boneLength += DynamicBone._tempVec1.length();
+      p._boneLength = boneLength;
+      pt._boneTotalLength = Math.max(pt._boneTotalLength, boneLength);
+      pt._particles[parentIndex]._childCount += 1;
+    }
+
+    const index = pt._particles.length;
+    pt._particles.push(p);
+
+    if (b != null) {
+      for (let i = 0; i < b.entity.children.length; i++) {
+        const child = b.entity.children[i];
+        let exclude = false;
+        if (this.exclusions.length != 0) {
+          const result = this.exclusions.find((value, index, obj) => {
+            return value === child.transform;
+          });
+          exclude = result != undefined;
+        }
+
+        DynamicBone._tempVec1.set(0, 0, 0);
+        if (!exclude) {
+          this._appendParticles(pt, child.transform, index, boneLength);
+        } else if (this.endLength > 0 || !Vector3.equals(this.endOffset, DynamicBone._tempVec1)) {
+          this._appendParticles(pt, null, index, boneLength);
+        }
+      }
+
+      if (
+        b.entity.children.length == 0 &&
+        (this.endLength > 0 || !Vector3.equals(this.endOffset, DynamicBone._tempVec1))
+      ) {
+        this._appendParticles(pt, null, index, boneLength);
+      }
+    }
+  }
+
+  private _isNeedUpdate(): boolean {
+    return this._weight > 0 && !(this.distantDisable && this._distantDisabled);
+  }
+
+  private _preUpdate(): void {
+    if (this._isNeedUpdate()) {
+      this._initTransforms();
+    }
+    this._preUpdateCount += 1;
+  }
+
+  private _checkDistance(): void {
+    if (!this.distantDisable) {
+      return;
+    }
+
+    const rt = this.referenceObject;
+    if (rt != null) {
+      Vector3.subtract(rt.worldPosition, this.entity.transform.worldPosition, DynamicBone._tempVec1);
+      const d2 = DynamicBone._tempVec1.lengthSquared();
+      const disable = d2 > this.distanceToObject * this.distanceToObject;
+      if (disable != this._distantDisabled) {
+        if (!disable) {
+          this._resetParticlesPosition();
+        }
+        this._distantDisabled = disable;
+      }
+    }
+  }
+
+  private _initTransforms(): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._initSingleTransforms(this._particleTrees[i]);
+    }
+  }
+
+  private _initSingleTransforms(pt: ParticleTree): void {
+    for (let i = 0; i < pt._particles.length; i++) {
+      let p = pt._particles[i];
+      let transform = p._transform;
+      if (transform != null) {
+        transform.position.copyFrom(p._initLocalPosition);
+        transform.rotationQuaternion.copyFrom(p._initLocalRotation);
+      }
+    }
+  }
+
+  private _resetParticlesPosition(): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._resetSingleParticlesPosition(this._particleTrees[i]);
+    }
+    this._objectPrevPosition.copyFrom(this.entity.transform.worldPosition);
+  }
+
+  private _resetSingleParticlesPosition(pt: ParticleTree): void {
+    for (let i = 0; i < pt._particles.length; i++) {
+      let p = pt._particles[i];
+      let transform = p._transform;
+      if (transform != null) {
+        p._position.copyFrom(transform.worldPosition);
+        p._prevPosition.copyFrom(transform.worldPosition);
+      } // end bone
+      else {
+        let pb = pt._particles[p._parentIndex]._transform;
+        let newPosition = DynamicBone._tempVec1;
+        Vector3.transformCoordinate(p._endOffset, pb!.worldMatrix, newPosition);
+        p._position.copyFrom(newPosition);
+        p._prevPosition.copyFrom(newPosition);
+      }
+      p._isCollide = false;
+    }
+  }
+
+  private _updateParticles1(timeVar: number, loopIndex: number): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._updateSingleParticles1(this._particleTrees[i], timeVar, loopIndex);
+    }
+  }
+
+  private _updateSingleParticles1(pt: ParticleTree, timeVar: number, loopIndex: number): void {
+    const force = DynamicBone._tempVec1;
+    force.copyFrom(this.gravity);
+    const fdir = DynamicBone._tempVec2;
+    Vector3.normalize(this.gravity, fdir);
+    // project current gravity to rest gravity
+    const scale = Math.max(Vector3.dot(pt._restGravity, fdir), 0);
+    const pf = DynamicBone._tempVec2;
+    Vector3.scale(fdir, scale, pf);
+    force.subtract(pf); // remove projected gravity
+    force.add(this.force);
+    force.scale(this._objectScale * timeVar);
+
+    // only first loop consider object move
+    const objectMove = DynamicBone._tempVec3;
+    if (loopIndex == 0) {
+      objectMove.copyFrom(this._objectMove);
+    } else {
+      objectMove.set(0, 0, 0);
+    }
+
+    for (let i = 0; i < pt._particles.length; i++) {
+      const p = pt._particles[i];
+      if (p._parentIndex >= 0) {
+        // verlet integration
+        const v = DynamicBone._tempVec2;
+        Vector3.subtract(p._position, p._prevPosition, v);
+        objectMove.scale(p._inert);
+        const rmove = objectMove;
+        Vector3.add(p._position, rmove, p._prevPosition);
+        let damping = p._damping;
+        if (p._isCollide) {
+          damping += p._friction;
+          if (damping > 1) {
+            damping = 1;
+          }
+          p._isCollide = false;
+        }
+        v.scale(1 - damping);
+        p._position.add(v);
+        p._position.add(force);
+        p._position.add(rmove);
+      } else {
+        p._prevPosition.copyFrom(p._position);
+        p._position.copyFrom(p._transformPosition);
+      }
+    }
+  }
+
+  private _updateParticles2(timeVar: number): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._updateSingleParticles2(this._particleTrees[i], timeVar);
+    }
+  }
+
+  private _updateSingleParticles2(pt: ParticleTree, timeVar: number): void {
+    const movePlane = DynamicBone._tempPlane;
+
+    for (let i = 1; i < pt._particles.length; i++) {
+      const p = pt._particles[i];
+      const p0 = pt._particles[p._parentIndex];
+
+      if (p._transform != null) {
+        Vector3.subtract(p0._transformPosition, p._transformPosition, DynamicBone._tempVec1);
+      } else {
+        Vector3.transformToVec3(p._endOffset, p0._transformLocalToWorldMatrix, DynamicBone._tempVec1);
+      }
+      const restLen = DynamicBone._tempVec1.length();
+
+      // keep shape
+      const stiffness = MathCommon.lerp(1.0, p._stiffness, this._weight);
+      if (stiffness > 0 || p._elasticity > 0) {
+        const m0 = DynamicBone._tempMatrix;
+        m0.copyFrom(p0._transformLocalToWorldMatrix);
+        m0.elements[12] = p0._position.x;
+        m0.elements[13] = p0._position.y;
+        m0.elements[14] = p0._position.z;
+
+        const restPos: Vector3 = DynamicBone._tempVec1;
+        if (p._transform != null) {
+          Vector3.transformToVec3(p._transformLocalPosition, m0, restPos);
+        } else {
+          Vector3.transformToVec3(p._endOffset, m0, restPos);
+        }
+
+        const d = DynamicBone._tempVec2;
+        Vector3.subtract(restPos, p._position, d);
+        d.scale(p._elasticity * timeVar);
+        p._position.add(d);
+
+        if (stiffness > 0) {
+          Vector3.subtract(restPos, p._position, d);
+          const len = d.length();
+          const maxlen = restLen * (1 - stiffness) * 2;
+          if (len > maxlen) {
+            d.scale((len - maxlen) / len);
+            p._position.add(d);
+          }
+        }
+      }
+
+      // collide
+      if (this._effectiveColliders.length != 0) {
+        const particleRadius = p._radius * this._objectScale;
+        for (let j = 0; j < this._effectiveColliders.length; j++) {
+          const c = this._effectiveColliders[j];
+          p._isCollide = p._isCollide || c.collide(p._position, particleRadius);
+        }
+      }
+
+      // freeze axis, project to plane
+      if (this.freezeAxis != FreezeAxis.None) {
+        const planeNormal = DynamicBone._tempVec1;
+        const elements = p0._transformLocalToWorldMatrix.elements;
+        planeNormal.x = elements[(this.freezeAxis - 1) * 4];
+        planeNormal.y = elements[(this.freezeAxis - 1) * 4 + 1];
+        planeNormal.z = elements[(this.freezeAxis - 1) * 4 + 2];
+        planeNormal.normalize();
+        movePlane.normal.copyFrom(planeNormal);
+        movePlane.distance = -Vector3.dot(planeNormal, p0._position);
+        planeNormal.scale(CollisionUtil.distancePlaneAndPoint(movePlane, p._position));
+        p._position.subtract(planeNormal);
+      }
+
+      // keep length
+      const dd = DynamicBone._tempVec1;
+      Vector3.subtract(p0._position, p._position, dd);
+      const leng = dd.length();
+      if (leng > 0) {
+        dd.scale((leng - restLen) / leng);
+        p._position.add(dd);
+      }
+    }
+  }
+
+  private _applyParticlesToTransforms(): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._applySingleParticlesToTransforms(this._particleTrees[i]);
+    }
+  }
+
+  private _applySingleParticlesToTransforms(pt: ParticleTree): void {
+    for (let i = 1; i < pt._particles.length; i++) {
+      let p = pt._particles[i];
+      let p0 = pt._particles[p._parentIndex];
+
+      // do not modify bone orientation if has more then one child
+      if (p0._childCount <= 1) {
+        let localPos: Vector3;
+        let transform = p._transform;
+        if (transform != null) {
+          localPos = transform.position;
+        } else {
+          localPos = p._endOffset;
+        }
+        let v0 = DynamicBone._tempVec1;
+        Vector3.transformToVec3(localPos, p0._transform!.worldMatrix, v0);
+        let v1 = DynamicBone._tempVec2;
+        Vector3.subtract(p._position, p0._position, v1);
+        let rot = DynamicBone._tempQuat;
+        MathCommon.shortestRotation(v0, v1, rot);
+        Quaternion.multiply(rot, p0._transform!.worldRotationQuaternion, rot);
+        p0._transform.worldRotationQuaternion.copyFrom(rot.normalize());
+      }
+
+      let transform = p._transform;
+      if (transform != null) {
+        transform.worldPosition.copyFrom(p._position);
+      }
+    }
+  }
+
+  private _skipUpdateParticles(): void {
+    for (let i = 0; i < this._particleTrees.length; i++) {
+      this._skipUpdateSingleParticles(this._particleTrees[i]);
+    }
+  }
+
+  private _skipUpdateSingleParticles(pt: ParticleTree): void {
+    for (let i = 0; i < pt._particles.length; i++) {
+      let p = pt._particles[i];
+      if (p._parentIndex >= 0) {
+        p._prevPosition.add(this._objectMove);
+        p._position.add(this._objectMove);
+
+        let p0 = pt._particles[p._parentIndex];
+
+        if (p._transform != null) {
+          Vector3.subtract(p0._transformPosition, p._transformPosition, DynamicBone._tempVec1);
+        } else {
+          Vector3.transformToVec3(p._endOffset, p0._transformLocalToWorldMatrix, DynamicBone._tempVec1);
+        }
+        const restLen = DynamicBone._tempVec1.length();
+
+        // keep shape
+        let stiffness = MathCommon.lerp(1.0, p._stiffness, this._weight);
+        if (stiffness > 0) {
+          let m0 = DynamicBone._tempMatrix;
+          m0.copyFrom(p0._transformLocalToWorldMatrix);
+          m0.elements[12] = p0._position.x;
+          m0.elements[13] = p0._position.y;
+          m0.elements[14] = p0._position.z;
+
+          let restPos: Vector3 = DynamicBone._tempVec1;
+          if (p._transform != null) {
+            Vector3.transformToVec3(p._transformLocalPosition, m0, restPos);
+          } else {
+            Vector3.transformToVec3(p._endOffset, m0, restPos);
+          }
+
+          let d = restPos;
+          d.subtract(p._position);
+          let len = d.length();
+          let maxlen = restLen * (1 - stiffness) * 2;
+          if (len > maxlen) {
+            d.scale((len - maxlen) / len);
+            p._position.add(d);
+          }
+        }
+
+        // keep length
+        let dd = DynamicBone._tempVec1;
+        Vector3.subtract(p0._position, p._position, dd);
+        let leng = dd.length();
+        if (leng > 0) {
+          dd.scale((leng - restLen) / leng);
+          p._position.add(dd);
+        }
+      } else {
+        p._prevPosition.copyFrom(p._position);
+        p._position.copyFrom(p._transformPosition);
+      }
+    }
+  }
+}
+
+class Particle {
+  _transform: Transform = null;
+  _parentIndex: number = 0;
+  _childCount: number = 0;
+  _damping: number = 0;
+  _elasticity: number = 0;
+  _stiffness: number = 0;
+  _inert: number = 0;
+  _friction: number = 0;
+  _radius: number = 0;
+  _boneLength: number = 0;
+  _isCollide: boolean = false;
+
+  _position = new Vector3();
+  _prevPosition = new Vector3();
+  _endOffset = new Vector3();
+  _initLocalPosition = new Vector3();
+  _initLocalRotation = new Quaternion();
+
+  // prepare data
+  _transformPosition = new Vector3();
+  _transformLocalPosition = new Vector3();
+  _transformLocalToWorldMatrix = new Matrix();
+}
+
+class ParticleTree {
+  _root: Transform = null;
+  _localGravity = new Vector3();
+  _rootWorldToLocalMatrix = new Matrix();
+  _boneTotalLength: number = 0;
+  _particles: Particle[] = [];
+
+  // prepare data
+  _restGravity = new Vector3();
+}

--- a/packages/dynamic-bone/src/DynamicBoneCollider.ts
+++ b/packages/dynamic-bone/src/DynamicBoneCollider.ts
@@ -1,0 +1,461 @@
+import { Bound, Direction, DynamicBoneColliderBase } from "./DynamicBoneColliderBase";
+import { Vector3 } from "@galacean/engine";
+import { MathCommon } from "./MathCommon";
+
+export class DynamicBoneCollider extends DynamicBoneColliderBase {
+  private static tempVec1 = new Vector3();
+  private static tempVec2 = new Vector3();
+  private static tempVec3 = new Vector3();
+
+  /// The radius of the sphere or capsule.
+  public radius: number = 0.5;
+
+  /// The height of the capsule.
+  public height: number = 0;
+
+  /// The other radius of the capsule.
+  public radius2: number = 0;
+
+  // prepare data
+  /** @internal */
+  _scaledRadius: number = 0;
+  /** @internal */
+  _scaledRadius2: number = 0;
+  /** @internal */
+  _c0: Vector3 = new Vector3();
+  /** @internal */
+  _c1: Vector3 = new Vector3();
+  /** @internal */
+  _c01Distance: number = 0;
+  /** @internal */
+  _collideType: number = 0;
+
+  override prepare(): void {
+    const worldMatrix = this.entity.transform.worldMatrix;
+    const scale = Math.abs(this.entity.transform.lossyWorldScale.x);
+    const halfHeight = this.height * 0.5;
+
+    if (this.radius2 <= 0 || Math.abs(this.radius - this.radius2) < 0.01) {
+      this._scaledRadius = this.radius * scale;
+
+      const h = halfHeight - this.radius;
+      if (h <= 0) {
+        Vector3.transformCoordinate(this.center, worldMatrix, this._c0);
+
+        if (this.bound == Bound.Outside) {
+          this._collideType = 0;
+        } else {
+          this._collideType = 1;
+        }
+      } else {
+        const c0 = DynamicBoneCollider.tempVec1;
+        c0.copyFrom(this.center);
+        const c1 = DynamicBoneCollider.tempVec2;
+        c1.copyFrom(this.center);
+
+        switch (this.direction) {
+          case Direction.X:
+            c0.x += h;
+            c1.x -= h;
+            break;
+          case Direction.Y:
+            c0.y += h;
+            c1.y -= h;
+            break;
+          case Direction.Z:
+            c0.z += h;
+            c1.z -= h;
+            break;
+        }
+
+        Vector3.transformCoordinate(c0, worldMatrix, this._c0);
+        Vector3.transformCoordinate(c1, worldMatrix, this._c1);
+        this._c01Distance = Vector3.distanceSquared(this._c1, this._c0);
+
+        if (this.bound == Bound.Outside) {
+          this._collideType = 2;
+        } else {
+          this._collideType = 3;
+        }
+      }
+    } else {
+      const r = Math.max(this.radius, this.radius2);
+      if (halfHeight - r <= 0) {
+        this._scaledRadius = r * scale;
+        Vector3.transformCoordinate(this.center, worldMatrix, this._c0);
+
+        if (this.bound == Bound.Outside) {
+          this._collideType = 0;
+        } else {
+          this._collideType = 1;
+        }
+      } else {
+        this._scaledRadius = this.radius * scale;
+        this._scaledRadius2 = this.radius2 * scale;
+
+        const h0 = halfHeight - this.radius;
+        const h1 = halfHeight - this.radius2;
+        const c0 = DynamicBoneCollider.tempVec1;
+        c0.copyFrom(this.center);
+        const c1 = DynamicBoneCollider.tempVec2;
+        c1.copyFrom(this.center);
+
+        switch (this.direction) {
+          case Direction.X:
+            c0.x += h0;
+            c1.x -= h1;
+            break;
+          case Direction.Y:
+            c0.y += h0;
+            c1.y -= h1;
+            break;
+          case Direction.Z:
+            c0.z += h0;
+            c1.z -= h1;
+            break;
+        }
+
+        Vector3.transformCoordinate(c0, worldMatrix, this._c0);
+        Vector3.transformCoordinate(c1, worldMatrix, this._c1);
+        this._c01Distance = Vector3.distance(this._c0, this._c1);
+
+        if (this.bound == Bound.Outside) {
+          this._collideType = 4;
+        } else {
+          this._collideType = 5;
+        }
+      }
+    }
+  }
+
+  override collide(particlePosition: Vector3, particleRadius: number): boolean {
+    switch (this._collideType) {
+      case 0:
+        return DynamicBoneCollider.outsideSphere(particlePosition, particleRadius, this._c0, this._scaledRadius);
+      case 1:
+        return DynamicBoneCollider.insideSphere(particlePosition, particleRadius, this._c0, this._scaledRadius);
+      case 2:
+        return DynamicBoneCollider.outsideCapsule(
+          particlePosition,
+          particleRadius,
+          this._c0,
+          this._c1,
+          this._scaledRadius,
+          this._c01Distance
+        );
+      case 3:
+        return DynamicBoneCollider.insideCapsule(
+          particlePosition,
+          particleRadius,
+          this._c0,
+          this._c1,
+          this._scaledRadius,
+          this._c01Distance
+        );
+      case 4:
+        return DynamicBoneCollider.outsideCapsule2(
+          particlePosition,
+          particleRadius,
+          this._c0,
+          this._c1,
+          this._scaledRadius,
+          this._scaledRadius2,
+          this._c01Distance
+        );
+      case 5:
+        return DynamicBoneCollider.insideCapsule2(
+          particlePosition,
+          particleRadius,
+          this._c0,
+          this._c1,
+          this._scaledRadius,
+          this._scaledRadius2,
+          this._c01Distance
+        );
+      default:
+        return false;
+    }
+  }
+
+  static outsideSphere(
+    particlePosition: Vector3,
+    particleRadius: number,
+    sphereCenter: Vector3,
+    sphereRadius: number
+  ): boolean {
+    const r = sphereRadius + particleRadius;
+    const r2 = r * r;
+    const d = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(particlePosition, sphereCenter, d);
+    const dlen2 = d.lengthSquared();
+
+    // if is inside sphere, project onto sphere surface
+    if (dlen2 > 0 && dlen2 < r2) {
+      const dlen = Math.sqrt(dlen2);
+      d.scale(r / dlen);
+      Vector3.add(sphereCenter, d, particlePosition);
+      return true;
+    }
+    return false;
+  }
+
+  static insideSphere(
+    particlePosition: Vector3,
+    particleRadius: number,
+    sphereCenter: Vector3,
+    sphereRadius: number
+  ): boolean {
+    const r = sphereRadius - particleRadius;
+    const r2 = r * r;
+    const d = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(particlePosition, sphereCenter, d);
+    const dlen2 = d.lengthSquared();
+
+    // if is outside sphere, project onto sphere surface
+    if (dlen2 > r2) {
+      const dlen = Math.sqrt(dlen2);
+      d.scale(r / dlen);
+      Vector3.add(sphereCenter, d, particlePosition);
+      return true;
+    }
+    return false;
+  }
+
+  static outsideCapsule(
+    particlePosition: Vector3,
+    particleRadius: number,
+    capsuleP0: Vector3,
+    capsuleP1: Vector3,
+    capsuleRadius: number,
+    dirlen: number
+  ): boolean {
+    const r = capsuleRadius + particleRadius;
+    const r2 = r * r;
+    const dir = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(capsuleP1, capsuleP0, dir);
+    const d = DynamicBoneCollider.tempVec2;
+    Vector3.subtract(particlePosition, capsuleP0, d);
+    const t = Vector3.dot(d, dir);
+
+    if (t <= 0) {
+      // check sphere1
+      const dlen2 = d.lengthSquared();
+      if (dlen2 > 0 && dlen2 < r2) {
+        const dlen = Math.sqrt(dlen2);
+        d.scale(r / dlen);
+        Vector3.add(capsuleP0, d, particlePosition);
+        return true;
+      }
+    } else {
+      const dirlen2 = dirlen * dirlen;
+      if (t >= dirlen2) {
+        // check sphere2
+        const d = DynamicBoneCollider.tempVec3;
+        Vector3.subtract(particlePosition, capsuleP1, d);
+        const dlen2 = d.lengthSquared();
+        if (dlen2 > 0 && dlen2 < r2) {
+          const dlen = Math.sqrt(dlen2);
+          d.scale(r / dlen);
+          Vector3.add(capsuleP1, d, particlePosition);
+          return true;
+        }
+      } else {
+        // check cylinder
+        const q = DynamicBoneCollider.tempVec3;
+        dir.scale(t / dirlen2);
+        Vector3.subtract(d, dir, q);
+        const qlen2 = q.lengthSquared();
+        if (qlen2 > 0 && qlen2 < r2) {
+          const qlen = Math.sqrt(qlen2);
+          q.scale((r - qlen) / qlen);
+          particlePosition.add(q);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static insideCapsule(
+    particlePosition: Vector3,
+    particleRadius: number,
+    capsuleP0: Vector3,
+    capsuleP1: Vector3,
+    capsuleRadius: number,
+    dirlen: number
+  ): boolean {
+    const r = capsuleRadius - particleRadius;
+    const r2 = r * r;
+    const dir = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(capsuleP1, capsuleP0, dir);
+    const d = DynamicBoneCollider.tempVec2;
+    Vector3.subtract(particlePosition, capsuleP0, d);
+    const t = Vector3.dot(d, dir);
+
+    if (t <= 0) {
+      // check sphere1
+      const dlen2 = d.lengthSquared();
+      if (dlen2 > r2) {
+        const dlen = Math.sqrt(dlen2);
+        d.scale(r / dlen);
+        Vector3.add(capsuleP0, d, particlePosition);
+        return true;
+      }
+    } else {
+      const dirlen2 = dirlen * dirlen;
+      if (t >= dirlen2) {
+        // check sphere2
+        const d = DynamicBoneCollider.tempVec3;
+        Vector3.subtract(particlePosition, capsuleP1, d);
+        const dlen2 = d.lengthSquared();
+        if (dlen2 > r2) {
+          const dlen = Math.sqrt(dlen2);
+          d.scale(r / dlen);
+          Vector3.add(capsuleP1, d, particlePosition);
+          return true;
+        }
+      } else {
+        // check cylinder
+        const q = DynamicBoneCollider.tempVec3;
+        dir.scale(t / dirlen2);
+        Vector3.subtract(d, dir, q);
+        const qlen2 = q.lengthSquared();
+        if (qlen2 > r2) {
+          const qlen = Math.sqrt(qlen2);
+          q.scale((r - qlen) / qlen);
+          particlePosition.add(q);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static outsideCapsule2(
+    particlePosition: Vector3,
+    particleRadius: number,
+    capsuleP0: Vector3,
+    capsuleP1: Vector3,
+    capsuleRadius0: number,
+    capsuleRadius1: number,
+    dirlen: number
+  ): boolean {
+    const dir = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(capsuleP1, capsuleP0, dir);
+    const d = DynamicBoneCollider.tempVec2;
+    Vector3.subtract(particlePosition, capsuleP0, d);
+    const t = Vector3.dot(d, dir);
+
+    if (t <= 0) {
+      // check sphere1
+      const r = capsuleRadius0 + particleRadius;
+      const r2 = r * r;
+      const dlen2 = d.lengthSquared();
+      if (dlen2 > 0 && dlen2 < r2) {
+        const dlen = Math.sqrt(dlen2);
+        d.scale(r / dlen);
+        Vector3.add(capsuleP0, d, particlePosition);
+        return true;
+      }
+    } else {
+      const dirlen2 = dirlen * dirlen;
+      if (t >= dirlen2) {
+        // check sphere2
+        const r = capsuleRadius1 + particleRadius;
+        const r2 = r * r;
+        const d = DynamicBoneCollider.tempVec3;
+        Vector3.subtract(particlePosition, capsuleP1, d);
+        const dlen2 = d.lengthSquared();
+        if (dlen2 > 0 && dlen2 < r2) {
+          const dlen = Math.sqrt(dlen2);
+          d.scale(r / dlen);
+          Vector3.add(capsuleP1, d, particlePosition);
+          return true;
+        }
+      } else {
+        // check cylinder
+        const q = DynamicBoneCollider.tempVec3;
+        Vector3.scale(dir, t / dirlen2, q);
+        Vector3.subtract(d, q, q);
+        const qlen2 = q.lengthSquared();
+
+        dir.scale(1 / dirlen);
+        const klen = Vector3.dot(d, dir);
+        const r = MathCommon.lerp(capsuleRadius0, capsuleRadius1, klen / dirlen) + particleRadius;
+        const r2 = r * r;
+
+        if (qlen2 > 0 && qlen2 < r2) {
+          const qlen = Math.sqrt(qlen2);
+          q.scale((r - qlen) / qlen);
+          particlePosition.add(q);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static insideCapsule2(
+    particlePosition: Vector3,
+    particleRadius: number,
+    capsuleP0: Vector3,
+    capsuleP1: Vector3,
+    capsuleRadius0: number,
+    capsuleRadius1: number,
+    dirlen: number
+  ): boolean {
+    const dir = DynamicBoneCollider.tempVec1;
+    Vector3.subtract(capsuleP1, capsuleP0, dir);
+    const d = DynamicBoneCollider.tempVec2;
+    Vector3.subtract(particlePosition, capsuleP0, d);
+    const t = Vector3.dot(d, dir);
+
+    if (t <= 0) {
+      // check sphere1
+      const r = capsuleRadius0 - particleRadius;
+      const r2 = r * r;
+      const dlen2 = d.lengthSquared();
+      if (dlen2 > r2) {
+        const dlen = Math.sqrt(dlen2);
+        d.scale(r / dlen);
+        Vector3.add(capsuleP0, d, particlePosition);
+        return true;
+      }
+    } else {
+      const dirlen2 = dirlen * dirlen;
+      if (t >= dirlen2) {
+        // check sphere2
+        const r = capsuleRadius1 - particleRadius;
+        const r2 = r * r;
+        const d = DynamicBoneCollider.tempVec3;
+        Vector3.subtract(particlePosition, capsuleP1, d);
+        const dlen2 = d.lengthSquared();
+        if (dlen2 > r2) {
+          const dlen = Math.sqrt(dlen2);
+          d.scale(r / dlen);
+          Vector3.add(capsuleP1, d, particlePosition);
+          return true;
+        }
+      } else {
+        // check cylinder
+        const q = DynamicBoneCollider.tempVec3;
+        Vector3.scale(dir, t / dirlen2, q);
+        Vector3.subtract(d, q, q);
+        const qlen2 = q.lengthSquared();
+
+        dir.scale(1 / dirlen);
+        const klen = Vector3.dot(d, dir);
+        const r = MathCommon.lerp(capsuleRadius0, capsuleRadius1, klen / dirlen) - particleRadius;
+        const r2 = r * r;
+
+        if (qlen2 > r2) {
+          const qlen = Math.sqrt(qlen2);
+          q.scale((r - qlen) / qlen);
+          particlePosition.add(q);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/packages/dynamic-bone/src/DynamicBoneColliderBase.ts
+++ b/packages/dynamic-bone/src/DynamicBoneColliderBase.ts
@@ -1,0 +1,31 @@
+import { Script, Vector3 } from "@galacean/engine";
+
+export enum Direction {
+  X,
+  Y,
+  Z
+}
+
+export enum Bound {
+  Outside,
+  Inside
+}
+
+export class DynamicBoneColliderBase extends Script {
+  /// The axis of the capsule's height.
+  public direction: Direction = Direction.Y;
+
+  /// The center of the sphere or capsule, in the object's local space.
+  public center = new Vector3();
+
+  /// Constrain bones to outside bound or inside bound.
+  public bound: Bound = Bound.Outside;
+
+  public prepareFrame: number = 0;
+
+  public prepare() {}
+
+  public collide(particlePosition: Vector3, particleRadius: number): boolean {
+    return false;
+  }
+}

--- a/packages/dynamic-bone/src/DynamicBonePlaneCollider.ts
+++ b/packages/dynamic-bone/src/DynamicBonePlaneCollider.ts
@@ -1,0 +1,50 @@
+import { Bound, Direction, DynamicBoneColliderBase } from "./DynamicBoneColliderBase";
+import { CollisionUtil, Plane, Vector3 } from "@galacean/engine";
+
+export class DynamicBonePlaneCollider extends DynamicBoneColliderBase {
+  private static tempVec = new Vector3();
+
+  /** @internal */
+  _plane = new Plane();
+
+  override prepare() {
+    let normal: Vector3;
+    switch (this.direction) {
+      case Direction.X:
+        normal = this.entity.transform.worldRight;
+        break;
+      case Direction.Y:
+        normal = this.entity.transform.worldUp;
+        break;
+      case Direction.Z:
+        normal = this.entity.transform.worldForward;
+        break;
+    }
+
+    const plane = this._plane;
+    const p = DynamicBonePlaneCollider.tempVec;
+    Vector3.transformCoordinate(this.center, this.entity.transform.worldMatrix, p);
+    Vector3.normalize(normal, plane.normal);
+    plane.distance = Vector3.dot(plane.normal, p);
+  }
+
+  override collide(particlePosition: Vector3, particleRadius: number): boolean {
+    const plane = this._plane;
+    const d = CollisionUtil.distancePlaneAndPoint(plane, particlePosition);
+
+    if (this.bound == Bound.Outside) {
+      if (d < 0) {
+        Vector3.scale(plane.normal, d, DynamicBonePlaneCollider.tempVec);
+        particlePosition.subtract(DynamicBonePlaneCollider.tempVec);
+        return true;
+      }
+    } else {
+      if (d > 0) {
+        Vector3.scale(plane.normal, d, DynamicBonePlaneCollider.tempVec);
+        particlePosition.subtract(DynamicBonePlaneCollider.tempVec);
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/dynamic-bone/src/MathCommon.ts
+++ b/packages/dynamic-bone/src/MathCommon.ts
@@ -1,0 +1,29 @@
+import { MathUtil, Vector3, Quaternion } from "@galacean/engine";
+
+export class MathCommon {
+  private static _tempVec = new Vector3();
+
+  public static lerp(a: number, b: number, t: number): number {
+    return a + (b - a) * MathUtil.clamp(t, 0, 1);
+  }
+
+  /// Creates a rotation which rotates from fromDirection to toDirection.
+  /// - Parameters:
+  ///   - from: the vector to start from
+  ///   - to: the vector to rotate to
+  /// - Returns: a rotation about an axis normal to the two vectors which takes one to the other via the shortest path
+  public static shortestRotation(from: Vector3, target: Vector3, quat: Quaternion): Quaternion {
+    const d = Vector3.dot(from, target);
+    const cross = MathCommon._tempVec;
+    Vector3.cross(from, target, cross);
+
+    const q =
+      d > -1
+        ? quat.set(cross.x, cross.y, cross.z, 1 + d)
+        : Math.abs(from.x) < 0.1
+        ? quat.set(0.0, from.z, -from.y, 0.0)
+        : quat.set(from.y, -from.x, 0.0, 0.0);
+
+    return q.normalize();
+  }
+}

--- a/packages/dynamic-bone/src/index.ts
+++ b/packages/dynamic-bone/src/index.ts
@@ -1,0 +1,3 @@
+export { DynamicBone, FreezeAxis, UpdateMode } from "./DynamicBone";
+export { DynamicBonePlaneCollider } from "./DynamicBonePlaneCollider";
+export { DynamicBoneCollider } from "./DynamicBoneCollider";

--- a/packages/dynamic-bone/tsconfig.json
+++ b/packages/dynamic-bone/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "declaration": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "declarationDir": "types",
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true,
+    "noImplicitOverride": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Dynamic bones are generally used to add physics-based animation to character animation, and can be used for hair,
ribbons, tails, and even clothing. Enhanced effects of original character animation.

Although spring motion can also be realized with a physics engine such as PhysX, dynamic bones generally need to
customize some motion curves to meet artistic needs. Therefore, this repository implements a custom small physics engine
to meet this requirement. This physics engine only implements particle-based spring animation, plus Capsule, Sphere,
and Plane colliders.

```ts
  var entity = createEntity(rootEntity, new Vector3(1, -1, 0), new Color(0, 0.7, 0));
  entity.addComponent(MoveScript);
  let dynamicBone = entity.addComponent(DynamicBone);
  dynamicBone.setWeight(0.9);

  entity = createEntity(entity, new Vector3(1, -1, 0));
  dynamicBone.root = entity.transform;

  entity = createEntity(entity, new Vector3(1, -1, 0));
  entity = createEntity(entity, new Vector3(1, -1, 0));
  entity = createEntity(entity, new Vector3(1, -1, 0));
  entity = createEntity(entity, new Vector3(1, -1, 0));
  entity = createEntity(entity, new Vector3(1, -1, 0));
  entity = createEntity(entity, new Vector3(1, -1, 0));

```