### PR TITLE
fix: ignore post-processing when framebuffer-picking

### DIFF
--- a/packages/framebuffer-picker/src/FramebufferPicker.ts
+++ b/packages/framebuffer-picker/src/FramebufferPicker.ts
@@ -130,6 +130,7 @@ export class FramebufferPicker extends Script {
     this._checkFrameBufferSize();
 
     const camera = this._camera;
+    const originPostProcessEnabled = camera.enablePostProcess;
     this._updateRenderersPickColor(camera.scene);
     // Prepare render target and shader
     const lastRenderTarget = camera.renderTarget;
@@ -138,12 +139,14 @@ export class FramebufferPicker extends Script {
     camera.setReplacementShader(pickShader);
     camera.aspectRatio = lastRatio;
 
+    camera.enablePostProcess = false;
     camera.render();
 
-    // Revert render target and shader
+    // Revert render target and shader, post-processing state
     camera.resetReplacementShader();
     camera.renderTarget = lastRenderTarget;
     camera.resetAspectRatio();
+    camera.enablePostProcess = originPostProcessEnabled;
   }
 
   private _readPixelFromRenderTarget(x: number, y: number, xEnd?: number, yEnd?: number): Uint8Array {

--- a/packages/framebuffer-picker/src/FramebufferPicker.ts
+++ b/packages/framebuffer-picker/src/FramebufferPicker.ts
@@ -2,6 +2,7 @@ import {
   Camera,
   dependentComponents,
   DependentMode,
+  DepthTextureMode,
   Logger,
   Renderer,
   RenderTarget,
@@ -130,7 +131,11 @@ export class FramebufferPicker extends Script {
     this._checkFrameBufferSize();
 
     const camera = this._camera;
-    const originPostProcessEnabled = camera.enablePostProcess;
+    const originalPostProcessEnabled = camera.enablePostProcess;
+    const originalHDR = camera.enableHDR;
+    const originalDepthMode = camera.depthTextureMode;
+    const originalOpaqueTextureEnabled = camera.opaqueTextureEnabled;
+
     this._updateRenderersPickColor(camera.scene);
     // Prepare render target and shader
     const lastRenderTarget = camera.renderTarget;
@@ -139,14 +144,24 @@ export class FramebufferPicker extends Script {
     camera.setReplacementShader(pickShader);
     camera.aspectRatio = lastRatio;
 
+    // Reset internal RT and useless pass
     camera.enablePostProcess = false;
+    camera.enableHDR = false;
+    camera.depthTextureMode = DepthTextureMode.None;
+    camera.opaqueTextureEnabled = false;
+
     camera.render();
 
-    // Revert render target and shader, post-processing state
+    // Revert render target and shader
     camera.resetReplacementShader();
     camera.renderTarget = lastRenderTarget;
     camera.resetAspectRatio();
-    camera.enablePostProcess = originPostProcessEnabled;
+
+    // Revert internal RT and original pass
+    camera.enablePostProcess = originalPostProcessEnabled;
+    camera.enableHDR = originalHDR;
+    camera.depthTextureMode = originalDepthMode;
+    camera.opaqueTextureEnabled = originalOpaqueTextureEnabled;
   }
 
   private _readPixelFromRenderTarget(x: number, y: number, xEnd?: number, yEnd?: number): Uint8Array {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering functionality in the Framebuffer Picker, improving state management of camera properties during operations.
  
- **Bug Fixes**
	- Fixed issues related to camera property alterations during rendering, ensuring original configurations are preserved post-operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->