### PR TITLE
Fix: sprite disable batching when pick

### DIFF
--- a/packages/framebuffer-picker/src/FramebufferPicker.ts
+++ b/packages/framebuffer-picker/src/FramebufferPicker.ts
@@ -9,6 +9,7 @@ import {
   Script,
   Shader,
   ShaderProperty,
+  SubShader,
   Texture2D,
   TextureFormat,
   Vector2,
@@ -18,6 +19,11 @@ import fs from "./color.fs.glsl";
 import vs from "./color.vs.glsl";
 
 const pickShader = Shader.create("framebuffer-picker-color", vs, fs);
+pickShader.subShaders.forEach((subShader: SubShader) => {
+  subShader.passes.forEach((pass) => {
+    pass.setTag("spriteDisableBatching", true);
+  });
+});
 
 /**
  * GPU Frame buffer picker.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
disable sprite batching when pick

resolve #295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced shader management by adding functionality for handling sub-shaders, allowing for more precise control over rendering configurations.
	- Introduced the ability to disable sprite batching for individual shader passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->