### PR TITLE
fix(build): externalize @galacean peers in miniprogram build instead of bundling

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -157,9 +157,13 @@ function makeRollupConfig(pkg) {
       sourcemap: false,
       format: "cjs"
     },
+    // Externalize each peer/dep both at its package name and its `/dist/miniprogram` entry:
+    // @galacean/engine is redirected to the latter by miniProgramPlugin, while peers without a
+    // dedicated miniprogram build (e.g. @galacean/engine-xr) stay external at the package name
+    // instead of being bundled in.
     external: Object.keys(Object.assign(pkg.pkgJson.dependencies ?? {}, pkg.pkgJson.peerDependencies ?? {}))
       .concat("@galacean/engine-miniprogram-adapter")
-      .map((name) => `${name}/dist/miniprogram`),
+      .flatMap((name) => [name, `${name}/dist/miniprogram`]),
     plugins: [...plugins, ...miniProgramPlugin]
   });
 

--- a/rollup.miniprogram.plugin.mjs
+++ b/rollup.miniprogram.plugin.mjs
@@ -42,14 +42,24 @@ adapterArray.forEach((name) => {
   adapterVars[name] = register(name);
 });
 
-const regStr = [`"@galacean/engine"`, `'@galacean/engine-xr'`].join("|");
+// Only `@galacean/engine` ships a dedicated miniprogram build whose specifier must be
+// redirected to `<pkg>/dist/miniprogram`; other @galacean peers (e.g. @galacean/engine-xr)
+// have no such entry and are externalized at their normal package name (see rollup.config.mjs).
+//
+// The previous implementation matched `@galacean/engine` with double quotes but
+// `@galacean/engine-xr` with single quotes; the transpiled source uses double quotes, so the
+// `@galacean/engine-xr` import was never matched, fell through to bundling, and dragged
+// @galacean/engine-math in with it — bloating dist/miniprogram.js by ~2MB. Matching either
+// quote and redirecting only the package that actually has a miniprogram build avoids both.
+const redirectModules = ["@galacean/engine"];
+const moduleAlternation = redirectModules.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
 
 export default [
   inject(adapterVars),
   modify({
-    find: new RegExp(regStr, "g"),
-    replace: (match, moduleName) => {
-      return `${match.substr(0, match.length - 1)}/dist/miniprogram"`;
-    }
+    // Match the specifier in single OR double quotes, anchored by a back-reference so
+    // `@galacean/engine` does not partially match `@galacean/engine-xr`.
+    find: new RegExp(`(['"])(${moduleAlternation})\\1`, "g"),
+    replace: (_match, quote, name) => `${quote}${name}/dist/miniprogram${quote}`
   })
 ];


### PR DESCRIPTION
Fixes #349.

## Problem

`@galacean/engine-toolkit-xr@1.6.0` ships a **~2.5 MB `dist/miniprogram.js`** (vs ~80 KB) because `@galacean/engine-xr` and its `@galacean/engine-math` dependency are **bundled inline** instead of kept external.

Two defects in the miniprogram build config:

1. **`rollup.config.mjs`** — the `external` list only contained the `<pkg>/dist/miniprogram` variants, so any peer import that wasn't redirected there fell through to bundling.
2. **`rollup.miniprogram.plugin.mjs`** — the redirect regex hard-coded mismatched quotes (`"@galacean/engine"` double, `'@galacean/engine-xr'` single). The transpiled source uses double quotes, so the `@galacean/engine-xr` import was never redirected → bundled → dragged `@galacean/engine-math` in with it.

Note: `@galacean/engine-xr` ships **no** `/dist/miniprogram` build (only `dist/main.js`/`dist/module.js`), so it must be externalized at its bare name — only `@galacean/engine` actually has a miniprogram build to redirect to.

## Change

- `external` now lists each peer/dep at **both** its package name and `/dist/miniprogram`, so a peer that isn't redirected stays external instead of being bundled.
- The redirect now targets **only `@galacean/engine`** and is **quote-agnostic** (matches single or double quotes, anchored by a back-reference so `@galacean/engine` can't partially match `@galacean/engine-xr`).

Result: `@galacean/engine` → `require('@galacean/engine/dist/miniprogram')`, `@galacean/engine-xr` → `require('@galacean/engine-xr')` (a path that exists), neither bundled.

## Verification

A full native `pnpm build` wasn't run here, so the fix was verified with a focused harness using the **real `rollup` + `rollup-plugin-modify`** and the exact `external` lists, stubbing the engine packages so only the external-vs-bundled decision is exercised:

```
OLD (buggy)   | engine -> /dist/miniprogram: true | engine-xr external(bare): false | engine-xr BUNDLED: true
NEW (fixed)   | engine -> /dist/miniprogram: true | engine-xr external(bare): true  | engine-xr BUNDLED: false
```

i.e. the original config bundles `@galacean/engine-xr`; the patched config externalizes it to `require('@galacean/engine-xr')`, while `@galacean/engine` stays redirected to its miniprogram build. A native build + a CI `dist/miniprogram.js` size guard would be a good follow-up to lock this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module redirection logic to prevent incorrect package path resolution in miniprogram builds

* **Chores**
  * Optimized miniprogram build configuration for improved dependency externalization handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->