### PR TITLE
fix(build): externalize @galacean peers in miniprogram build instead of bundling

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -199,9 +199,13 @@ function makeRollupConfig(pkg) {
       sourcemap: false,
       format: "cjs"
     },
+    // Externalize each peer/dep both at its package name and its `/dist/miniprogram` entry:
+    // @galacean/engine is redirected to the latter by miniProgramPlugin, while peers without a
+    // dedicated miniprogram build (e.g. @galacean/engine-xr) stay external at the package name
+    // instead of being bundled in.
     external: Object.keys(Object.assign(pkg.pkgJson.dependencies ?? {}, pkg.pkgJson.peerDependencies ?? {}))
       .concat("@galacean/engine-miniprogram-adapter")
-      .map((name) => `${name}/dist/miniprogram`),
+      .flatMap((name) => [name, `${name}/dist/miniprogram`]),
     plugins: [...plugins, ...miniProgramPlugin]
   });
 

--- a/rollup.miniprogram.plugin.mjs
+++ b/rollup.miniprogram.plugin.mjs
@@ -42,14 +42,24 @@ adapterArray.forEach((name) => {
   adapterVars[name] = register(name);
 });
 
-const regStr = [`"@galacean/engine"`, `'@galacean/engine-xr'`].join("|");
+// Only `@galacean/engine` ships a dedicated miniprogram build whose specifier must be
+// redirected to `<pkg>/dist/miniprogram`; other @galacean peers (e.g. @galacean/engine-xr)
+// have no such entry and are externalized at their normal package name (see rollup.config.mjs).
+//
+// The previous implementation matched `@galacean/engine` with double quotes but
+// `@galacean/engine-xr` with single quotes; the transpiled source uses double quotes, so the
+// `@galacean/engine-xr` import was never matched, fell through to bundling, and dragged
+// @galacean/engine-math in with it — bloating dist/miniprogram.js by ~2MB. Matching either
+// quote and redirecting only the package that actually has a miniprogram build avoids both.
+const redirectModules = ["@galacean/engine"];
+const moduleAlternation = redirectModules.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
 
 export default [
   inject(adapterVars),
   modify({
-    find: new RegExp(regStr, "g"),
-    replace: (match, moduleName) => {
-      return `${match.substr(0, match.length - 1)}/dist/miniprogram"`;
-    }
+    // Match the specifier in single OR double quotes, anchored by a back-reference so
+    // `@galacean/engine` does not partially match `@galacean/engine-xr`.
+    find: new RegExp(`(['"])(${moduleAlternation})\\1`, "g"),
+    replace: (_match, quote, name) => `${quote}${name}/dist/miniprogram${quote}`
   })
 ];


### PR DESCRIPTION
Fixes #349 on the `dev/2.0` (2.0) line. Counterpart of #350 (which targets `main`/1.x).

`dev/2.0` carries the identical miniprogram build defect, so the same fix is cherry-picked here: externalize each peer/dep at both its package name and `/dist/miniprogram`, and redirect only `@galacean/engine` (quote-agnostic). `@galacean/engine-xr` then stays external as `require('@galacean/engine-xr')` instead of being bundled (which inlined ~2MB of engine-xr + engine-math into `dist/miniprogram.js`).

See #349 / #350 for the full root-cause analysis and the rollup + rollup-plugin-modify verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined miniprogram Rollup configuration to improve dependency externalization and module redirection accuracy in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->