### PR TITLE
chore: rename oasis to galacean in README badges and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Galacean Engine Toolkit
 
-<a href="https://www.npmjs.com/package/oasis-engine-toolkit"><img src="https://img.shields.io/npm/v/oasis-engine-toolkit"/></a> ![npm-size](https://img.shields.io/bundlephobia/minzip/oasis-engine-toolkit) ![npm-download](https://img.shields.io/npm/dm/oasis-engine-toolkit) [![codecov](https://codecov.io/gh/oasis-engine/engine/branch/main/graph/badge.svg?token=KR2UBKE3OX)](https://codecov.io/gh/oasis-engine/engine-toolkit)
+<a href="https://www.npmjs.com/package/@galacean/engine-toolkit"><img src="https://img.shields.io/npm/v/@galacean/engine-toolkit"/></a> ![npm-size](https://img.shields.io/bundlephobia/minzip/@galacean/engine-toolkit) ![npm-download](https://img.shields.io/npm/dm/@galacean/engine-toolkit) [![codecov](https://codecov.io/gh/galacean/engine/branch/main/graph/badge.svg?token=KR2UBKE3OX)](https://codecov.io/gh/galacean/engine-toolkit)
 
 Some out-of-the-box utility features based on the [Galacean engine](https://github.com/galacean/engine) `Script` and `Material`, welcome to enjoy!
 

--- a/packages/galacean-engine-toolkit/README.md
+++ b/packages/galacean-engine-toolkit/README.md
@@ -1,6 +1,6 @@
 # Galacean Engine Toolkit
 
-<a href="https://www.npmjs.com/package/oasis-engine-toolkit"><img src="https://img.shields.io/npm/v/oasis-engine-toolkit"/></a> ![npm-size](https://img.shields.io/bundlephobia/minzip/oasis-engine-toolkit) ![npm-download](https://img.shields.io/npm/dm/oasis-engine-toolkit) [![codecov](https://codecov.io/gh/oasis-engine/engine/branch/main/graph/badge.svg?token=KR2UBKE3OX)](https://codecov.io/gh/oasis-engine/engine-toolkit)
+<a href="https://www.npmjs.com/package/@galacean/engine-toolkit"><img src="https://img.shields.io/npm/v/@galacean/engine-toolkit"/></a> ![npm-size](https://img.shields.io/bundlephobia/minzip/@galacean/engine-toolkit) ![npm-download](https://img.shields.io/npm/dm/@galacean/engine-toolkit) [![codecov](https://codecov.io/gh/galacean/engine/branch/main/graph/badge.svg?token=KR2UBKE3OX)](https://codecov.io/gh/galacean/engine-toolkit)
 
 Some out-of-the-box utility features based on the [Galacean engine](https://github.com/galacean/engine/) `Script` and `Material`, welcome to enjoy!
 


### PR DESCRIPTION
- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package badges and links in the README files to reflect the new `@galacean/engine-toolkit` package name.
  * Kept the rest of the documented content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->